### PR TITLE
Ability to set owner and group on the configuration file

### DIFF
--- a/data/common.yaml
+++ b/data/common.yaml
@@ -9,3 +9,5 @@ apmserver::package_config_path: /etc/apm-server
 apmserver::service_ensure: running
 apmserver::service_enable: 'true'
 apmserver::service_name: apm-server
+apmserver::config_owner: root
+apmserver::config_group: root

--- a/manifests/config.pp
+++ b/manifests/config.pp
@@ -11,6 +11,8 @@ class apmserver::config (
   Hash $apmserver_config_custom                   = $apmserver::apmserver_config_custom,
   String $ori_ext                                 = $apmserver::_ori_ext,
   Optional[String] $apmserver_default_config_file = $apmserver::apmserver_default_config_file,
+  String $owner                                   = $apmserver::owner,
+  String $group                                   = $apmserver::group,
 ){
 
   $_file_ensure = $package_ensure ? {
@@ -33,6 +35,8 @@ class apmserver::config (
     ensure  => $_file_ensure,
     content => $apmserver_config_combined,
     mode    => '0600',
+    owner   => $owner,
+    group   => $group,
   }
 
 }

--- a/manifests/config.pp
+++ b/manifests/config.pp
@@ -11,8 +11,8 @@ class apmserver::config (
   Hash $apmserver_config_custom                   = $apmserver::apmserver_config_custom,
   String $ori_ext                                 = $apmserver::_ori_ext,
   Optional[String] $apmserver_default_config_file = $apmserver::apmserver_default_config_file,
-  String $owner                                   = $apmserver::owner,
-  String $group                                   = $apmserver::group,
+  String $config_owner                            = $apmserver::config_owner,
+  String $config_group                            = $apmserver::config_group,
 ){
 
   $_file_ensure = $package_ensure ? {
@@ -35,8 +35,8 @@ class apmserver::config (
     ensure  => $_file_ensure,
     content => $apmserver_config_combined,
     mode    => '0600',
-    owner   => $owner,
-    group   => $group,
+    owner   => $config_owner,
+    group   => $config_group,
   }
 
 }

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -69,6 +69,12 @@
 #
 # @apmserver_default_config_file
 #   Full path to the packages default configuration file.  Default: undef
+# 
+# @config_owner
+#   Parameter to set the owner of the configuration file
+# 
+# @config_group
+#   Parameter to set the group of the configuration file
 #
 class apmserver (
   Boolean $manage_repo,
@@ -83,6 +89,8 @@ class apmserver (
   String $service_name,
   Hash $apmserver_config_custom = {},
   Optional[String] $apmserver_default_config_file = undef,
+  String $config_owner,
+  String $config_group,
 ){
 
   if $::osfamily == 'RedHat' {


### PR DESCRIPTION
Hello,

Would it be possible to add this feature to the module? I would like to run apm-server as a non-root user but with the current permissions on the config file it seems impossible to do ("permission denied" on the file when starting apm as apm-server user).

Thank you!

